### PR TITLE
see the result of compress

### DIFF
--- a/src/Hooks/useRubickImage.tsx
+++ b/src/Hooks/useRubickImage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { minBy, sample } from "lodash";
 import { getOffscreenContext, colorDistance, resizeImageCanvas } from "../tools";
 import { RubickFace } from "../types";
+import { compressRubickCubeData } from "../compress";
 
 interface Color {
   red: number;
@@ -104,6 +105,7 @@ export default function useRubickImage({ initialTileSize = tileSizeDefault } : R
           newRubicksPixels.push(rubickFace);
         }
       }
+      console.log(compressRubickCubeData(newRubicksPixels, expectedWidth));
       setRubickFaces(newRubicksPixels);
   }
 

--- a/src/compress.ts
+++ b/src/compress.ts
@@ -1,0 +1,62 @@
+import { RubickFace } from "./types";
+
+type CaracterColorType = "W"| "R" | "Y" |"O" |"B" | "G";
+
+
+function fromHexToCaracterColor(color: string) : CaracterColorType  {
+    switch(color) {
+    case "#FFFFFF":
+    default:
+        return "W";
+    case "#7CCF57":
+        return "G";
+    case "#EECF4E":
+        return "Y";
+    case "#EC702D":
+        return "O";
+    case "#FFFFFF":
+        return "W";
+    case "#BD2827":
+        return "R";
+    case "#2C5DA6":
+        return "B";
+    }
+}
+
+export function compressRubickCubeData(rubickFaces: RubickFace[], width: number) : string {
+    const rubickFacesFlatten = rubickFaces.flat(2);
+
+    const rubickFacesFlattenSortByXAndY = rubickFacesFlatten.slice().sort( (a,b) => {
+        return (a.x + (a.y * width)) - (b.x + (b.y * width));
+    });
+
+    let compressRubickFaces = "";
+
+    let nbOccurenceContigous = 0;
+    let contigousColor = "";
+
+    rubickFacesFlattenSortByXAndY.forEach(({color}) => {
+        const caracterColor = fromHexToCaracterColor(color);
+
+        if(caracterColor === contigousColor) {
+            nbOccurenceContigous += 1;
+        } else {
+            if(nbOccurenceContigous !== 0) {
+                compressRubickFaces += `${contigousColor}${nbOccurenceContigous}`;
+            }
+
+            nbOccurenceContigous = 1;
+            contigousColor = caracterColor
+        }
+    });
+
+    if(nbOccurenceContigous !== 0) {
+        compressRubickFaces += `${contigousColor}${nbOccurenceContigous}`;
+    }
+
+    return compressRubickFaces;
+}
+
+export function createRubickFacesFromCompressData(compressData: string) : RubickFace[] {
+
+}


### PR DESCRIPTION
this feature is very limited because some renders still to big to be passed as query string param. That being said, It is impossible based on this data to change the size of the rubick cube image

A better solution to exporting render would be to store user params configuration and store the image in service provider